### PR TITLE
重写文件选择按钮

### DIFF
--- a/module/config/argument/args.json
+++ b/module/config/argument/args.json
@@ -185,7 +185,15 @@
       },
       "LauncherPath": {
         "type": "textarea",
-        "value": ""
+        "value": "",
+        "path_picker": {
+          "enabled": true,
+          "mode": "file",
+          "accept": [
+            ".exe"
+          ],
+          "after_select": "autofill_game_path_from_launcher"
+        }
       },
       "LauncherTitleName": {
         "type": "input",
@@ -197,7 +205,14 @@
       },
       "GamePath": {
         "type": "textarea",
-        "value": ""
+        "value": "",
+        "path_picker": {
+          "enabled": true,
+          "mode": "file",
+          "accept": [
+            ".exe"
+          ]
+        }
       },
       "GameTitleName": {
         "type": "input",

--- a/module/config/argument/argument.yaml
+++ b/module/config/argument/argument.yaml
@@ -82,6 +82,11 @@ PCClientInfo:
   LauncherPath:
     value: ''
     type: textarea
+    path_picker:
+      enabled: true
+      mode: file
+      accept: [ .exe ]
+      after_select: autofill_game_path_from_launcher
   LauncherTitleName:
     value: ''
   LauncherProcessName:
@@ -89,6 +94,10 @@ PCClientInfo:
   GamePath:
     value: ''
     type: textarea
+    path_picker:
+      enabled: true
+      mode: file
+      accept: [ .exe ]
   GameTitleName:
     value: ''
   GameProcessName:

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -1787,14 +1787,32 @@ class NKASGUI(Frame):
             )
 
             def _close_startup_notice():
+                checked = False
                 try:
-                    if eval_js(
+                    checked = bool(
+                        eval_js(
                         'document.getElementById(checkbox_id) && document.getElementById(checkbox_id).checked',
                         checkbox_id=checkbox_id,
-                    ):
-                        State.deploy_config.StartupNoticeDismissedId = notice_id
+                        )
+                    )
                 except Exception as e:
                     logger.warning(f'Failed to parse startup notice checkbox: {e}')
+
+                if checked:
+                    try:
+                        State.deploy_config.StartupNoticeDismissedId = notice_id
+                        if isinstance(State.deploy_config.config, dict):
+                            State.deploy_config.config['StartupNoticeDismissedId'] = notice_id
+                        State.deploy_config.write()
+                        deploy_config_path = getattr(State.deploy_config, 'file', './config/deploy.yaml')
+                        logger.info(
+                            f'Startup notice dismissed id saved: {notice_id}, deploy config: {deploy_config_path}'
+                        )
+                    except Exception as e:
+                        deploy_config_path = getattr(State.deploy_config, 'file', './config/deploy.yaml')
+                        logger.warning(
+                            f'Failed to save startup notice dismissed id [{notice_id}] to [{deploy_config_path}]: {e}'
+                        )
                 close_popup()
 
             popup(

--- a/module/webui/widgets.py
+++ b/module/webui/widgets.py
@@ -416,268 +416,67 @@ def put_arg_state(kwargs: T_Output_Kwargs) -> Output:
     )
 
 
-def put_arg_textarea(kwargs: T_Output_Kwargs) -> Output:
-    name: str = kwargs["name"]
-    mode: str = kwargs.pop("mode", None)
-    kwargs.setdefault(
-        "code", {"lineWrapping": True, "lineNumbers": False, "mode": mode}
-    )
+def _normalize_windows_path(path: str) -> str:
+    import os
 
-    # For PC client executable path fields, provide a native file picker button.
-    path_picker_accept_map = {
-        "PCClient_PCClientInfo_LauncherPath": ".exe",
-        "PCClient_PCClientInfo_GamePath": ".exe",
+    raw = str(path or '').strip()
+    if raw == '':
+        return ''
+    normalized = os.path.normpath(raw)
+    return normalized.replace('/', '\\')
+
+
+def _resolve_path_picker(name: str, raw_picker: Any) -> Optional[Dict[str, Any]]:
+    legacy_picker_map = {
+        'PCClient_PCClientInfo_LauncherPath': {
+            'mode': 'file',
+            'accept': ['.exe'],
+            'after_select': 'autofill_game_path_from_launcher',
+        },
+        'PCClient_PCClientInfo_GamePath': {
+            'mode': 'file',
+            'accept': ['.exe'],
+        },
     }
-    accept = path_picker_accept_map.get(name)
-    if accept is not None:
-        def _pick_file():
-            from pywebio.pin import pin
-            import os
-            import ctypes
-            from ctypes import wintypes
 
-            def _normalize_windows_path(path: str) -> str:
-                raw = str(path or '').strip()
-                if raw == '':
-                    return ''
-                normalized = os.path.normpath(raw)
-                # Keep UI/config consistent on Windows.
-                return normalized.replace('/', '\\')
+    picker = None
+    if isinstance(raw_picker, dict):
+        picker = copy.deepcopy(raw_picker)
+    elif raw_picker is True:
+        picker = {}
+    elif raw_picker is None:
+        picker = copy.deepcopy(legacy_picker_map.get(name))
 
-            def _dialog_options(ext: str):
-                suffix = str(ext or '').strip()
-                if suffix and not suffix.startswith('.'):
-                    suffix = f'.{suffix}'
-                if not suffix:
-                    suffix = '.exe'
-                pattern = f'*{suffix}'
-                if suffix.lower() == '.exe':
-                    label = 'Executable Files'
-                else:
-                    label = f'{suffix[1:].upper()} Files'
-                return label, pattern, suffix[1:]
+    if picker is None:
+        return None
+    if picker.get('enabled', True) is False:
+        return None
 
-            def _pick_file_windows_native(title: str, ext: str) -> str:
-                if os.name != 'nt':
-                    return ''
+    mode = 'directory' if picker.get('mode') == 'directory' else 'file'
+    accept = picker.get('accept', [])
+    if isinstance(accept, str):
+        accept = [accept]
+    if not isinstance(accept, list):
+        accept = []
+    accept = [str(ext).strip() for ext in accept if str(ext).strip()]
 
-                class OPENFILENAMEW(ctypes.Structure):
-                    _fields_ = [
-                        ('lStructSize', wintypes.DWORD),
-                        ('hwndOwner', wintypes.HWND),
-                        ('hInstance', wintypes.HINSTANCE),
-                        ('lpstrFilter', wintypes.LPCWSTR),
-                        ('lpstrCustomFilter', wintypes.LPWSTR),
-                        ('nMaxCustFilter', wintypes.DWORD),
-                        ('nFilterIndex', wintypes.DWORD),
-                        ('lpstrFile', wintypes.LPWSTR),
-                        ('nMaxFile', wintypes.DWORD),
-                        ('lpstrFileTitle', wintypes.LPWSTR),
-                        ('nMaxFileTitle', wintypes.DWORD),
-                        ('lpstrInitialDir', wintypes.LPCWSTR),
-                        ('lpstrTitle', wintypes.LPCWSTR),
-                        ('Flags', wintypes.DWORD),
-                        ('nFileOffset', wintypes.WORD),
-                        ('nFileExtension', wintypes.WORD),
-                        ('lpstrDefExt', wintypes.LPCWSTR),
-                        ('lCustData', wintypes.LPARAM),
-                        ('lpfnHook', ctypes.c_void_p),
-                        ('lpTemplateName', wintypes.LPCWSTR),
-                        ('pvReserved', ctypes.c_void_p),
-                        ('dwReserved', wintypes.DWORD),
-                        ('FlagsEx', wintypes.DWORD),
-                    ]
+    return {
+        'mode': mode,
+        'accept': accept,
+        'title': str(picker.get('title') or '').strip(),
+        'title_key': str(
+            picker.get('title_i18n_key')
+            or picker.get('title_key')
+            or ''
+        ).strip(),
+        'button_label': str(picker.get('button_label') or '').strip(),
+        'after_select': picker.get('after_select'),
+    }
 
-                label, pattern, def_ext = _dialog_options(ext)
-                # OPENFILENAME filter must be null-separated and double-null terminated.
-                lpstr_filter = f'{label} ({pattern})\0{pattern}\0All Files (*.*)\0*.*\0\0'
-                file_buffer = ctypes.create_unicode_buffer(32768)
 
-                ofn = OPENFILENAMEW()
-                ofn.lStructSize = ctypes.sizeof(OPENFILENAMEW)
-                ofn.lpstrFilter = lpstr_filter
-                ofn.lpstrFile = file_buffer
-                ofn.nMaxFile = len(file_buffer)
-                ofn.lpstrTitle = title
-                ofn.lpstrDefExt = def_ext
-                ofn.Flags = (
-                    0x00000004  # OFN_HIDEREADONLY
-                    | 0x00000008  # OFN_NOCHANGEDIR
-                    | 0x00000800  # OFN_PATHMUSTEXIST
-                    | 0x00001000  # OFN_FILEMUSTEXIST
-                    | 0x00080000  # OFN_EXPLORER
-                )
-
-                if ctypes.windll.comdlg32.GetOpenFileNameW(ctypes.byref(ofn)):
-                    return file_buffer.value
-
-                err = ctypes.windll.comdlg32.CommDlgExtendedError()
-                if err != 0:
-                    raise OSError(f'GetOpenFileNameW failed with code {err}')
-                return ''
-
-            def _pick_file_tk(title: str, ext: str) -> str:
-                label, pattern, _ = _dialog_options(ext)
-                root = None
-                try:
-                    import tkinter as tk
-                    from tkinter import filedialog
-
-                    root = tk.Tk()
-                    root.withdraw()
-                    try:
-                        root.attributes('-topmost', True)
-                        root.update()
-                    except Exception:
-                        pass
-
-                    return filedialog.askopenfilename(
-                        title=title,
-                        filetypes=[
-                            (label, pattern),
-                            ('All Files', '*.*'),
-                        ],
-                    )
-                finally:
-                    if root is not None:
-                        try:
-                            root.destroy()
-                        except Exception:
-                            pass
-
-            selected = ''
-            picker_errors = []
-            dialog_title = t("Gui.Text.ChooseFile")
-            try:
-                selected = _pick_file_windows_native(dialog_title, accept)
-            except Exception as e:
-                picker_errors.append(f'win32={e}')
-
-            if not selected:
-                try:
-                    selected = _pick_file_tk(dialog_title, accept)
-                except Exception as e:
-                    picker_errors.append(f'tk={e}')
-
-            if not selected and picker_errors:
-                logger.warning(
-                    f'Native file picker unavailable for {name}: {"; ".join(picker_errors)}'
-                )
-                toast('File picker unavailable, please input path manually.', color='error')
-                return
-
-            selected = _normalize_windows_path(selected)
-            if not selected:
-                return
-
-            pin[name] = selected
-            nkasgui: "NKASGUI" = local.gui
-            nkasgui.modified_config_queue.put(
-                {"name": ".".join(name.split("_")), "value": selected}
-            )
-            logger.info(f'Path picker selected: {name}={selected}')
-
-            # Keep the same autofill behavior as startup flow:
-            # selecting LauncherPath auto-populates GamePath.
-            if name == "PCClient_PCClientInfo_LauncherPath":
-                config = nkasgui.nkas_config.read_file(nkasgui.nkas_name)
-
-                def _safe_pin_value(pin_name, fallback=''):
-                    try:
-                        val = pin[pin_name]
-                    except Exception:
-                        val = fallback
-                    return val
-
-                client = str(
-                    _safe_pin_value(
-                        "PCClient_PCClientInfo_Client",
-                        config.get("PCClient", {}).get("PCClientInfo", {}).get("Client", "intl"),
-                    )
-                    or "intl"
-                ).strip()
-                auto_fill_raw = _safe_pin_value(
-                    "PCClient_PCClientInfo_AutoFillName",
-                    config.get("PCClient", {}).get("PCClientInfo", {}).get("AutoFillName", True),
-                )
-                if isinstance(auto_fill_raw, list):
-                    auto_fill_name = bool(auto_fill_raw)
-                else:
-                    auto_fill_name = bool(auto_fill_raw)
-
-                game_process_pin = str(
-                    _safe_pin_value(
-                        "PCClient_PCClientInfo_GameProcessName",
-                        config.get("PCClient", {}).get("PCClientInfo", {}).get("GameProcessName", ""),
-                    )
-                    or ""
-                ).strip()
-
-                default_game_process_map = {
-                    "intl": "nikke.exe",
-                    "hmt": "nikke.exe",
-                }
-                default_game_process = default_game_process_map.get(client, "nikke.exe")
-                game_process = default_game_process if auto_fill_name else (game_process_pin or default_game_process)
-
-                game_pin_name = "PCClient_PCClientInfo_GamePath"
-                current_game_path = _normalize_windows_path(
-                    _safe_pin_value(
-                        game_pin_name,
-                        config.get("PCClient", {}).get("PCClientInfo", {}).get("GamePath", ""),
-                    )
-                    or ""
-                )
-
-                # Only auto-fill when GamePath is currently empty.
-                if current_game_path:
-                    logger.info(
-                        f'Skip launcher autofill because {game_pin_name} is not empty: {current_game_path}'
-                    )
-                    return
-
-                launcher_dir = os.path.dirname(os.path.normpath(selected))
-                game_path = _normalize_windows_path(
-                    os.path.join(launcher_dir, "..", "NIKKE", "game", game_process)
-                )
-                pin[game_pin_name] = game_path
-                nkasgui.modified_config_queue.put(
-                    {"name": ".".join(game_pin_name.split("_")), "value": game_path}
-                )
-                logger.info(f'Auto-filled from launcher path: {game_pin_name}={game_path}')
-
-        button_scope = f"arg_path_picker_btn_{name}"
-        row = put_row(
-            [
-                put_textarea(**kwargs),
-                put_scope(
-                    button_scope,
-                    [
-                        put_button(
-                            label=t("Gui.Text.ChooseFile"),
-                            onclick=_pick_file,
-                            color="primary",
-                            small=True,
-                        ),
-                    ],
-                ).style(
-                    "display: flex; align-items: center; justify-content: flex-start; "
-                    "height: 100%; min-height: 2.2rem;"
-                ),
-            ],
-            size="1fr auto",
-        ).style("align-items: stretch; column-gap: .45rem;")
-
-        scope = put_scope(
-            f"arg_contianer-textarea-{name}",
-            [
-                get_title_help(kwargs),
-                row,
-            ],
-        )
-
-        run_js(
-            """
+def _apply_path_picker_button_style(button_scope: str, disabled: bool, disabled_title: str) -> None:
+    run_js(
+        """
 (() => {
     const scopeName = button_scope_name;
     const applyStyle = (attempt) => {
@@ -707,17 +506,272 @@ def put_arg_textarea(kwargs: T_Output_Kwargs) -> Output:
         btn.style.justifyContent = 'center';
         btn.style.marginTop = '0';
         btn.style.marginLeft = '.25rem';
+        if (is_disabled) {
+            btn.title = disabled_hint;
+            btn.style.opacity = '0.65';
+            btn.style.cursor = 'not-allowed';
+        }
     };
     applyStyle(0);
 })();
-            """,
-            button_scope_name=button_scope,
-        )
+        """,
+        button_scope_name=button_scope,
+        is_disabled=disabled,
+        disabled_hint=disabled_title,
+    )
 
+
+def _pick_path_via_electron(payload: Dict[str, Any]) -> Dict[str, Any]:
+    return eval_js(
+        """
+        (async (pickerOptions) => {
+            const requestId = `pick-path-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            return await new Promise((resolve) => {
+                let settled = false;
+                const finish = (value) => {
+                    if (settled) return;
+                    settled = true;
+                    window.removeEventListener('message', onMessage);
+                    clearTimeout(timeoutId);
+                    resolve(value);
+                };
+                const onMessage = (event) => {
+                    const data = event && event.data ? event.data : null;
+                    if (!data || data.source !== 'nkas-electron') return;
+                    if (data.type !== 'dialog:pick-path:response') return;
+                    if (data.requestId !== requestId) return;
+                    finish(data.payload || {
+                        ok: false,
+                        canceled: false,
+                        path: '',
+                        error: 'Empty response payload',
+                    });
+                };
+                const timeoutId = setTimeout(() => {
+                    finish({
+                        ok: false,
+                        canceled: false,
+                        path: '',
+                        error: 'File picker response timed out',
+                    });
+                }, 15000);
+
+                window.addEventListener('message', onMessage);
+                try {
+                    if (!window.parent || window.parent === window) {
+                        throw new Error('No parent window available');
+                    }
+                    window.parent.postMessage({
+                        source: 'nkas-webui',
+                        type: 'dialog:pick-path:request',
+                        requestId,
+                        payload: pickerOptions || {},
+                    }, '*');
+                } catch (error) {
+                    const reason = (error && error.message) ? String(error.message) : String(error);
+                    finish({
+                        ok: false,
+                        canceled: false,
+                        path: '',
+                        error: reason,
+                    });
+                }
+            });
+        })(pickerOptions)
+        """,
+        pickerOptions=payload,
+    )
+
+
+def _queue_modified_config(name: str, value: str) -> None:
+    from pywebio.pin import pin
+
+    pin[name] = value
+    nkasgui: 'NKASGUI' = local.gui
+    nkasgui.modified_config_queue.put(
+        {'name': '.'.join(name.split('_')), 'value': value}
+    )
+
+
+def _autofill_game_path_from_launcher(launcher_path: str) -> None:
+    from pywebio.pin import pin
+    import os
+
+    nkasgui: 'NKASGUI' = local.gui
+    config = nkasgui.nkas_config.read_file(nkasgui.nkas_name)
+
+    def _safe_pin_value(pin_name, fallback=''):
+        try:
+            val = pin[pin_name]
+        except Exception:
+            val = fallback
+        return val
+
+    client = str(
+        _safe_pin_value(
+            'PCClient_PCClientInfo_Client',
+            config.get('PCClient', {}).get('PCClientInfo', {}).get('Client', 'intl'),
+        )
+        or 'intl'
+    ).strip()
+    auto_fill_raw = _safe_pin_value(
+        'PCClient_PCClientInfo_AutoFillName',
+        config.get('PCClient', {}).get('PCClientInfo', {}).get('AutoFillName', True),
+    )
+    auto_fill_name = bool(auto_fill_raw)
+
+    game_process_pin = str(
+        _safe_pin_value(
+            'PCClient_PCClientInfo_GameProcessName',
+            config.get('PCClient', {}).get('PCClientInfo', {}).get('GameProcessName', ''),
+        )
+        or ''
+    ).strip()
+
+    default_game_process_map = {
+        'intl': 'nikke.exe',
+        'hmt': 'nikke.exe',
+    }
+    default_game_process = default_game_process_map.get(client, 'nikke.exe')
+    game_process = default_game_process if auto_fill_name else (game_process_pin or default_game_process)
+
+    game_pin_name = 'PCClient_PCClientInfo_GamePath'
+    current_game_path = _normalize_windows_path(
+        _safe_pin_value(
+            game_pin_name,
+            config.get('PCClient', {}).get('PCClientInfo', {}).get('GamePath', ''),
+        )
+        or ''
+    )
+
+    if current_game_path:
+        logger.info(
+            f'Skip launcher autofill because {game_pin_name} is not empty: {current_game_path}'
+        )
+        return
+
+    launcher_dir = os.path.dirname(os.path.normpath(launcher_path))
+    game_path = _normalize_windows_path(
+        os.path.join(launcher_dir, '..', 'NIKKE', 'game', game_process)
+    )
+    _queue_modified_config(game_pin_name, game_path)
+    logger.info(f'Auto-filled from launcher path: {game_pin_name}={game_path}')
+
+
+def put_arg_textarea(kwargs: T_Output_Kwargs) -> Output:
+    name: str = kwargs['name']
+    mode: str = kwargs.pop('mode', None)
+    path_picker_raw = kwargs.pop('path_picker', None)
+    kwargs.setdefault(
+        'code', {'lineWrapping': True, 'lineNumbers': False, 'mode': mode}
+    )
+    picker = _resolve_path_picker(name, path_picker_raw)
+    if picker is not None:
+        picker_title = picker['title']
+        picker_title_key = picker['title_key']
+        if not picker_title and picker_title_key:
+            try:
+                picker_title = t(picker_title_key)
+            except Exception:
+                picker_title = ''
+        if not picker_title:
+            picker_title = t('Gui.Text.ChooseFile')
+        button_label = picker['button_label'] or t('Gui.Text.ChooseFile')
+        button_disabled = not State.electron
+        disabled_hint = 'File picker is available only in Electron client.'
+        after_select_handlers = {
+            'autofill_game_path_from_launcher': _autofill_game_path_from_launcher,
+        }
+
+        def _pick_path():
+            from pywebio.pin import pin
+
+            if not State.electron:
+                toast(disabled_hint, color='warning')
+                return
+
+            try:
+                current_raw = pin[name]
+            except Exception:
+                current_raw = kwargs.get('value', '')
+            current_value = _normalize_windows_path(str(current_raw or '').strip())
+            payload = {
+                'mode': picker['mode'],
+                'title': picker_title,
+                'defaultPath': current_value or None,
+                'accept': picker['accept'],
+            }
+            result = {}
+            try:
+                result = _pick_path_via_electron(payload)
+            except Exception as e:
+                logger.warning(f'Electron picker invoke failed for {name}: {e}')
+                toast('File picker failed, please input path manually.', color='error')
+                return
+
+            if not isinstance(result, dict):
+                logger.warning(f'Unexpected picker response for {name}: {result}')
+                toast('File picker failed, please input path manually.', color='error')
+                return
+            if result.get('canceled'):
+                return
+            if not result.get('ok'):
+                reason = str(result.get('error') or 'unknown error')
+                logger.warning(f'File picker failed for {name}: {reason}')
+                toast('File picker failed, please input path manually.', color='error')
+                return
+
+            selected = _normalize_windows_path(result.get('path'))
+            if not selected:
+                return
+
+            _queue_modified_config(name, selected)
+            logger.info(f'Path picker selected: {name}={selected}')
+
+            after_select = picker.get('after_select')
+            if isinstance(after_select, str):
+                handler = after_select_handlers.get(after_select)
+                if handler is not None:
+                    try:
+                        handler(selected)
+                    except Exception as e:
+                        logger.warning(f'After-select hook failed for {name}: {e}')
+
+        button_scope = f'arg_path_picker_btn_{name}'
+        row = put_row(
+            [
+                put_textarea(**kwargs),
+                put_scope(
+                    button_scope,
+                    [
+                        put_button(
+                            label=button_label,
+                            onclick=_pick_path,
+                            color='primary',
+                            small=True,
+                            disabled=button_disabled,
+                        ),
+                    ],
+                ).style(
+                    'display: flex; align-items: center; justify-content: flex-start; '
+                    'height: 100%; min-height: 2.2rem;'
+                ),
+            ],
+            size='1fr auto',
+        ).style('align-items: stretch; column-gap: .45rem;')
+
+        scope = put_scope(
+            f'arg_contianer-textarea-{name}',
+            [
+                get_title_help(kwargs),
+                row,
+            ],
+        )
+        _apply_path_picker_button_style(button_scope, button_disabled, disabled_hint)
         return scope
 
     return put_scope(
-        f"arg_contianer-textarea-{name}",
+        f'arg_contianer-textarea-{name}',
         [
             get_title_help(kwargs),
             put_textarea(**kwargs),

--- a/webapp/packages/main/src/index.ts
+++ b/webapp/packages/main/src/index.ts
@@ -1,4 +1,4 @@
-import { app, Menu, Tray, BrowserWindow, ipcMain, globalShortcut } from 'electron';
+import { app, Menu, Tray, BrowserWindow, ipcMain, globalShortcut, dialog, type OpenDialogOptions } from 'electron';
 import { URL } from 'url';
 import { PyShell } from '/@/pyshell';
 import { webuiArgs, webuiPath, dpiScaling, webuiUrl, nkasPath } from '/@/config';
@@ -36,6 +36,48 @@ nkas.end(function (err: string) {
 });
 
 let mainWindow: BrowserWindow | null = null;
+
+function normalizeDialogAccept(accept: unknown) {
+  if (!Array.isArray(accept)) return [];
+  return accept
+    .filter((item) => typeof item === 'string')
+    .map((item) => String(item).trim())
+    .filter((item) => item.length > 0)
+    .map((item) => item.startsWith('.') ? item.slice(1) : item)
+    .filter((item) => item.length > 0);
+}
+
+ipcMain.handle('dialog:pick-path', async (_event, rawOptions: any) => {
+  try {
+    const options = rawOptions && typeof rawOptions === 'object' ? rawOptions : {};
+    const mode = options.mode === 'directory' ? 'directory' : 'file';
+    const title = typeof options.title === 'string' ? options.title : '';
+    const defaultPath = typeof options.defaultPath === 'string' ? options.defaultPath : undefined;
+
+    const dialogOptions: OpenDialogOptions = {
+      title: title || undefined,
+      defaultPath,
+      properties: mode === 'directory' ? ['openDirectory'] : ['openFile'],
+    };
+
+    if (mode === 'file') {
+      const extensions = normalizeDialogAccept(options.accept);
+      if (extensions.length > 0) {
+        dialogOptions.filters = [{ name: 'Allowed Files', extensions }];
+      }
+    }
+
+    const result = await dialog.showOpenDialog(mainWindow ?? undefined, dialogOptions);
+    if (result.canceled || !result.filePaths || result.filePaths.length === 0) {
+      return { ok: true, canceled: true, path: '', error: '' };
+    }
+
+    return { ok: true, canceled: false, path: result.filePaths[0], error: '' };
+  } catch (error: any) {
+    const message = (error && error.message) ? String(error.message) : String(error);
+    return { ok: false, canceled: false, path: '', error: message };
+  }
+});
 
 /**
  * 创建主窗口

--- a/webapp/packages/main/vite.config.js
+++ b/webapp/packages/main/vite.config.js
@@ -1,6 +1,6 @@
-import {node} from '../../electron-vendors.config.json';
-import {join} from 'path';
-import {builtinModules} from 'module';
+const {join} = require('path');
+const {builtinModules} = require('module');
+const {node} = require('../../electron-vendors.config.json');
 
 const PACKAGE_ROOT = __dirname;
 
@@ -9,7 +9,7 @@ const PACKAGE_ROOT = __dirname;
  * @type {import('vite').UserConfig}
  * @see https://vitejs.dev/config/
  */
-const config = {
+module.exports = {
   mode: process.env.MODE,
   root: PACKAGE_ROOT,
   envDir: process.cwd(),
@@ -49,5 +49,3 @@ const config = {
     brotliSize: false,
   },
 };
-
-export default config;

--- a/webapp/packages/preload/vite.config.js
+++ b/webapp/packages/preload/vite.config.js
@@ -1,6 +1,6 @@
-import {chrome} from '../../electron-vendors.config.json';
-import {join} from 'path';
-import {builtinModules} from 'module';
+const {join} = require('path');
+const {builtinModules} = require('module');
+const {chrome} = require('../../electron-vendors.config.json');
 
 const PACKAGE_ROOT = __dirname;
 
@@ -8,7 +8,7 @@ const PACKAGE_ROOT = __dirname;
  * @type {import('vite').UserConfig}
  * @see https://vitejs.dev/config/
  */
-const config = {
+module.exports = {
   mode: process.env.MODE,
   root: PACKAGE_ROOT,
   envDir: process.cwd(),
@@ -47,5 +47,3 @@ const config = {
     brotliSize: false,
   },
 };
-
-export default config;

--- a/webapp/packages/renderer/src/components/NKAS.vue
+++ b/webapp/packages/renderer/src/components/NKAS.vue
@@ -5,12 +5,85 @@
 <script lang="ts">
   import {defineComponent} from 'vue';
   import {webuiUrl} from '../../../main/src/config';
+  const ipcRenderer = require('electron').ipcRenderer;
+
+  type PickerMode = 'file' | 'directory';
+
+  interface PickerRequestPayload {
+    mode?: PickerMode;
+    title?: string;
+    defaultPath?: string;
+    accept?: string[];
+  }
+
+  interface PickerRequestMessage {
+    source: string;
+    type: string;
+    requestId: string;
+    payload?: PickerRequestPayload;
+  }
 
   export default defineComponent({
     name: 'NKAS',
+    data() {
+      return {
+        webuiOrigin: new URL(webuiUrl).origin,
+      };
+    },
     computed: {
       url: function () {
         return webuiUrl;
+      },
+    },
+    mounted() {
+      window.addEventListener('message', this.onWebuiMessage);
+    },
+    beforeUnmount() {
+      window.removeEventListener('message', this.onWebuiMessage);
+    },
+    methods: {
+      async onWebuiMessage(event: MessageEvent) {
+        if (event.origin !== this.webuiOrigin) return;
+
+        const data = event.data as PickerRequestMessage;
+        if (!data || data.source !== 'nkas-webui') return;
+        if (data.type !== 'dialog:pick-path:request') return;
+        if (!data.requestId || typeof data.requestId !== 'string') return;
+
+        const payload = (data.payload && typeof data.payload === 'object') ? data.payload : {};
+        const mode: PickerMode = payload.mode === 'directory' ? 'directory' : 'file';
+        const title = typeof payload.title === 'string' ? payload.title : '';
+        const defaultPath = typeof payload.defaultPath === 'string' ? payload.defaultPath : '';
+        const accept = Array.isArray(payload.accept)
+          ? payload.accept.filter((item) => typeof item === 'string').map((item) => String(item))
+          : [];
+
+        const responseBase = {
+          source: 'nkas-electron',
+          type: 'dialog:pick-path:response',
+          requestId: data.requestId,
+        };
+        const source = event.source as MessageEventSource | null;
+        const sendResponse = (payload: any) => {
+          if (!source || typeof (source as any).postMessage !== 'function') return;
+          (source as any).postMessage({
+            ...responseBase,
+            payload,
+          }, event.origin);
+        };
+
+        try {
+          const result = await ipcRenderer.invoke('dialog:pick-path', {
+            mode,
+            title,
+            defaultPath,
+            accept,
+          });
+          sendResponse(result);
+        } catch (error: any) {
+          const message = (error && error.message) ? String(error.message) : String(error);
+          sendResponse({ ok: false, canceled: false, path: '', error: message });
+        }
       },
     },
   });

--- a/webapp/packages/renderer/vite.config.js
+++ b/webapp/packages/renderer/vite.config.js
@@ -1,9 +1,9 @@
 /* eslint-env node */
 
-import {chrome} from '../../electron-vendors.config.json';
-import {join} from 'path';
-import {builtinModules} from 'module';
-import vue from '@vitejs/plugin-vue';
+const {join} = require('path');
+const {builtinModules} = require('module');
+const vue = require('@vitejs/plugin-vue');
+const {chrome} = require('../../electron-vendors.config.json');
 
 const PACKAGE_ROOT = __dirname;
 
@@ -11,7 +11,7 @@ const PACKAGE_ROOT = __dirname;
  * @type {import('vite').UserConfig}
  * @see https://vitejs.dev/config/
  */
-const config = {
+module.exports = {
   mode: process.env.MODE,
   root: PACKAGE_ROOT,
   resolve: {
@@ -47,5 +47,3 @@ const config = {
     brotliSize: false,
   },
 };
-
-export default config;


### PR DESCRIPTION
## Summary by Sourcery

集成一个基于 Electron 的新文件/路径选择器，用于 Windows 客户端配置字段；重构 textarea 参数处理逻辑，以支持可配置的路径选择器并带有可选的自动填充逻辑；同时确保启动通知的关闭操作能够持久化保存到部署配置中。

New Features:
- 为 textarea 参数新增可配置的路径选择器支持，包括用于 PC 客户端启动器和游戏路径的、由 Electron 支持的文件选择功能。
- 引入 Electron 渲染进程-主进程的 IPC 流程，根据来自 Web UI 的选项处理文件和目录打开对话框。

Enhancements:
- 重构 Windows 路径标准化以及游戏路径自动填充逻辑，将其抽取为可复用的辅助方法，并由 Web UI 共享使用。
- 将启动通知的关闭（dismiss）ID 持久化到部署配置文件中，并对成功与失败情况进行日志记录。
- 将 Electron 包中的 Vite 配置切换为 CommonJS 导出，以更好地兼容现有构建设置。

Build:
- 将 renderer、main 和 preload 的 Vite 配置文件从 ES module 语法转换为 CommonJS 的 `module.exports`，以与 Node 风格的 `require` 对齐。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a new Electron-based file/path picker for Windows client configuration fields, refactor textarea argument handling to support configurable path pickers with optional autofill logic, and ensure startup notice dismissal is persisted to the deploy config.

New Features:
- Add configurable path picker support to textarea arguments, including Electron-backed file selection for PC client launcher and game paths.
- Introduce an Electron renderer-main IPC flow to handle file and directory open dialogs based on options from the web UI.

Enhancements:
- Refactor Windows path normalization and game path autofill logic into reusable helpers shared by the web UI.
- Persist startup notice dismissal IDs to the deployment configuration file with logging for success and failure cases.
- Switch Vite configs in Electron packages to CommonJS exports for better compatibility with the existing build setup.

Build:
- Convert renderer, main, and preload Vite configuration files from ES module syntax to CommonJS module.exports to align with Node-style requires.

</details>