### PR TITLE
增加启动更新失败提示

### DIFF
--- a/deploy/config.py
+++ b/deploy/config.py
@@ -8,7 +8,12 @@ from module.logger import logger
 from typing import Optional, Union
 
 class ExecutionError(Exception):
-    pass
+    def __init__(self, message='', command=None, error_code=None):
+        if not message and command is not None and error_code is not None:
+            message = f'{command} failed with exit code {error_code}'
+        super().__init__(message)
+        self.command = command
+        self.error_code = error_code
 
 
 class ConfigModel:
@@ -138,7 +143,7 @@ class DeployConfig(ConfigModel):
             else:
                 logger.info(f"[ failure ], error_code: {error_code}")
                 self.show_error(command)
-                raise ExecutionError
+                raise ExecutionError(command=command, error_code=error_code)
         else:
             logger.info(f"[ success ]")
             return True

--- a/deploy/git.py
+++ b/deploy/git.py
@@ -80,13 +80,6 @@ class GitManager(DeployConfig):
         self.execute(f'"{self.git}" reset --hard {source}/{branch}')
         self.execute(f'"{self.git}" pull --ff-only {source} {branch}')
 
-        """
-            清理悬空对象和压缩体积
-        """
-        logger.hr('Cleaning up git garbage', 1)
-        self.execute(f'"{self.git}" reflog expire --expire=now --all', allow_failure=True)
-        self.execute(f'"{self.git}" gc --prune=now', allow_failure=True)
-
         logger.hr('Show Version', 1)
         self.execute(f'"{self.git}" --no-pager log --no-merges -1')
 

--- a/deploy/starter.py
+++ b/deploy/starter.py
@@ -12,6 +12,7 @@ from deploy.pip import PipManager
 
 class Starter(GitManager, PipManager, NKASManager):
     AUTO_UPDATE_NOTICE_PATH = './log/auto_update_notice.json'
+    AUTO_UPDATE_FAILED_NOTICE_PATH = './log/auto_update_failed_notice.json'
 
     def _execute_output(self, command: str) -> str:
         return subprocess.run(
@@ -51,6 +52,7 @@ class Starter(GitManager, PipManager, NKASManager):
         if not before_sha or not after_sha or before_sha == after_sha:
             return
 
+        self._remove_notice_file(self.AUTO_UPDATE_FAILED_NOTICE_PATH)
         rev_range = f'{before_sha}..{after_sha}'
         payload = {
             'updated_at': datetime.now().isoformat(timespec='seconds'),
@@ -63,6 +65,26 @@ class Starter(GitManager, PipManager, NKASManager):
         with open(self.AUTO_UPDATE_NOTICE_PATH, 'w', encoding='utf-8') as f:
             json.dump(payload, f, ensure_ascii=False)
 
+    @staticmethod
+    def _remove_notice_file(path: str):
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        except Exception:
+            pass
+
+    def _save_auto_update_failed_notice(self, error: str):
+        error = str(error).strip() or 'Unknown error'
+        self._remove_notice_file(self.AUTO_UPDATE_NOTICE_PATH)
+        payload = {
+            'updated_at': datetime.now().isoformat(timespec='seconds'),
+            'error': error,
+        }
+        os.makedirs(os.path.dirname(self.AUTO_UPDATE_FAILED_NOTICE_PATH), exist_ok=True)
+        with open(self.AUTO_UPDATE_FAILED_NOTICE_PATH, 'w', encoding='utf-8') as f:
+            json.dump(payload, f, ensure_ascii=False)
+
     def start(self):
         from deploy.atomic import atomic_failure_cleanup
 
@@ -70,10 +92,16 @@ class Starter(GitManager, PipManager, NKASManager):
         try:
             if self.AutoUpdate:
                 before_sha, _ = self._get_head_commit()
-                self.git_update()
-                self.pip_install()
-                after_sha, _ = self._get_head_commit()
-                self._save_auto_update_notice(before_sha, after_sha)
+                try:
+                    self.git_update()
+                except ExecutionError as e:
+                    error = str(e).strip() or 'Git update failed'
+                    print(f'Auto update failed, skip update and continue startup: {error}')
+                    self._save_auto_update_failed_notice(error)
+                else:
+                    self.pip_install()
+                    after_sha, _ = self._get_head_commit()
+                    self._save_auto_update_notice(before_sha, after_sha)
             self.nkas_kill()
         except ExecutionError:
             input('Press Enter to continue...')  # Keep window open

--- a/module/config/argument/gui.yaml
+++ b/module/config/argument/gui.yaml
@@ -28,6 +28,7 @@ Toast:
   ClickToUpdate:
   AutoUpdated:
   AutoUpdatedWithContent:
+  AutoUpdateFailed:
 
 Status:
   Running:

--- a/module/config/i18n/en-US.json
+++ b/module/config/i18n/en-US.json
@@ -1282,7 +1282,8 @@
       "NKASIsRunning": "Scheduler is already running",
       "ClickToUpdate": "Update available — click here to update",
       "AutoUpdated": "Auto-updated to {sha} ({count} commits). Click for details",
-      "AutoUpdatedWithContent": "Auto-updated to {sha} ({count} commits):\n{content}"
+      "AutoUpdatedWithContent": "Auto-updated to {sha} ({count} commits):\n{content}",
+      "AutoUpdateFailed": "Auto update failed: \n{error}"
     },
     "Status": {
       "Running": "Running",

--- a/module/config/i18n/ja-JP.json
+++ b/module/config/i18n/ja-JP.json
@@ -1282,7 +1282,8 @@
       "NKASIsRunning": "スケジューラはすでに実行中です",
       "ClickToUpdate": "更新が利用可能です。ここをクリックして更新を実行してください",
       "AutoUpdated": "自動更新完了: {sha}（{count}件）。クリックで詳細を表示",
-      "AutoUpdatedWithContent": "自動更新完了: {sha}（{count}件）:\n{content}"
+      "AutoUpdatedWithContent": "自動更新完了: {sha}（{count}件）:\n{content}",
+      "AutoUpdateFailed": "自動更新に失敗しました: \n{error}"
     },
     "Status": {
       "Running": "実行中",

--- a/module/config/i18n/zh-CN.json
+++ b/module/config/i18n/zh-CN.json
@@ -1282,7 +1282,8 @@
       "NKASIsRunning": "调度器已在运行中",
       "ClickToUpdate": "有更新可用，点击这里进行更新",
       "AutoUpdated": "已自动更新到 {sha}（{count} 条提交），点击查看详情",
-      "AutoUpdatedWithContent": "已自动更新到 {sha}（{count} 条提交）：\n{content}"
+      "AutoUpdatedWithContent": "已自动更新到 {sha}（{count} 条提交）：\n{content}",
+      "AutoUpdateFailed": "自动更新失败：\n{error}"
     },
     "Status": {
       "Running": "运行中",

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -1704,7 +1704,7 @@ class NKASGUI(Frame):
             error = str(data.get('error', '')).strip() or 'Unknown error'
             toast(
                 t('Gui.Toast.AutoUpdateFailed', error=error),
-                duration=10,
+                duration=0,
                 position='right',
                 color='error',
             )

--- a/module/webui/app.py
+++ b/module/webui/app.py
@@ -1679,6 +1679,36 @@ class NKASGUI(Frame):
                 onclick=goto_update,
             )
 
+        def show_auto_update_failed_toast_once():
+            notice_paths = [
+                './log/auto_update_failed_notice.json',
+            ]
+            notice_path = next((p for p in notice_paths if os.path.exists(p)), '')
+            if not notice_path:
+                return
+
+            try:
+                with open(notice_path, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+            except Exception as e:
+                logger.warning(f'Failed to read auto update failed notice: {e}')
+                data = {}
+            finally:
+                try:
+                    os.remove(notice_path)
+                except FileNotFoundError:
+                    pass
+                except Exception as e:
+                    logger.warning(f'Failed to remove auto update failed notice: {e}')
+
+            error = str(data.get('error', '')).strip() or 'Unknown error'
+            toast(
+                t('Gui.Toast.AutoUpdateFailed', error=error),
+                duration=10,
+                position='right',
+                color='error',
+            )
+
         def show_startup_notice_popup_once():
             notice_path = './config/startup_notice.yaml'
             if not os.path.exists(notice_path):
@@ -1866,6 +1896,7 @@ class NKASGUI(Frame):
         self.task_handler.add(update_switch.g(), 1)
         self.task_handler.start()
         show_auto_update_toast_once()
+        show_auto_update_failed_toast_once()
         show_startup_notice_popup_once()
 
         # Return to previous page


### PR DESCRIPTION
## Summary by Sourcery

为自动更新失败添加面向用户的通知，并从部署命令中传播详细的执行错误信息。

New Features:
- 将自动更新失败的详细信息记录到由日志支持的通知文件中，以便稍后在 UI 中显示。
- 当自动更新失败时，在 GUI 中显示一次性的 toast 提示，并包含错误信息。

Enhancements:
- 扩展 `ExecutionError`，使其携带命令和退出码的详细信息，并在从命令执行中抛出失败时使用这些信息。
- 通过在写入前清除相反状态的通知文件，确保自动更新成功和失败通知互斥。
- 通过移除自动 git 垃圾回收步骤，简化 git 仓库初始化流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add user-facing notifications for automatic update failures and propagate detailed execution errors from deployment commands.

New Features:
- Record automatic update failure details to a log-backed notice file for later display in the UI.
- Display a one-time toast in the GUI when an automatic update fails, including the error message.

Enhancements:
- Extend ExecutionError to carry command and exit code details and use them when raising failures from command execution.
- Ensure success and failure auto-update notices are mutually exclusive by clearing the opposite notice file before writing.
- Simplify git repository initialization by removing automatic git garbage collection steps.

</details>